### PR TITLE
Added missing keys to info.plist

### DIFF
--- a/AppRTC/Info.plist
+++ b/AppRTC/Info.plist
@@ -48,5 +48,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
Starting with iOS 10, NSCameraUsageDescription and NSMicrophoneUsageDescription should be explicitly added into info.plist, otherwise application crashes when camera/mic access is needed. This commit adds these keys and fixes those crashes. 