### PR TITLE
Handle NSInvalidArgumentException from parse error

### DIFF
--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -197,7 +197,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
                                  userInfo:userInfo];
       [strongSelf.delegate appClient:strongSelf didError:error];
       return;
-    } else if (response && response.result !=  kARDRegisterResultTypeSuccess) {
+    } else if (response.result ==  kARDRegisterResultTypeUnknown) {
         //Error in parsing response data
         [strongSelf disconnect];
         NSDictionary *userInfo = @{

--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -189,7 +189,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
           (int)response.result);
       [strongSelf disconnect];
       NSDictionary *userInfo = @{
-        NSLocalizedDescriptionKey: @"Room is full.",
+        NSLocalizedDescriptionKey: @"Room is full."
       };
       NSError *error =
           [[NSError alloc] initWithDomain:kARDAppClientErrorDomain
@@ -208,6 +208,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
                                    code:kARDAppClientErrorNetwork
                                userInfo:userInfo];
         [strongSelf.delegate appClient:strongSelf didError:error];
+        return;
     }
     NSLog(@"Registered with room server.");
     strongSelf.roomId = response.roomId;

--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -201,11 +201,11 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
         //Error in parsing response data
         [strongSelf disconnect];
         NSDictionary *userInfo = @{
-          NSLocalizedDescriptionKey: @"Room server network error"
+          NSLocalizedDescriptionKey: @"Unknown error occurred."
         };
         NSError *error =
         [[NSError alloc] initWithDomain:kARDAppClientErrorDomain
-                                   code:kARDAppClientErrorNetwork
+                                   code:kARDAppClientErrorUnknown
                                userInfo:userInfo];
         [strongSelf.delegate appClient:strongSelf didError:error];
         return;

--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -184,7 +184,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
   [self registerWithRoomServerForRoomId:roomId
                       completionHandler:^(ARDRegisterResponse *response) {
     ARDAppClient *strongSelf = weakSelf;
-    if (!response || response.result != kARDRegisterResultTypeSuccess) {
+    if (!response) {
       NSLog(@"Failed to register with room server. Result:%d",
           (int)response.result);
       [strongSelf disconnect];
@@ -197,6 +197,17 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
                                  userInfo:userInfo];
       [strongSelf.delegate appClient:strongSelf didError:error];
       return;
+    } else if (response && response.result !=  kARDRegisterResultTypeSuccess) {
+        //Error in parsing response data
+        [strongSelf disconnect];
+        NSDictionary *userInfo = @{
+          NSLocalizedDescriptionKey: @"Room server network error",
+        };
+        NSError *error =
+        [[NSError alloc] initWithDomain:kARDAppClientErrorDomain
+                                   code:kARDAppClientErrorNetwork
+                               userInfo:userInfo];
+        [strongSelf.delegate appClient:strongSelf didError:error];
     }
     NSLog(@"Registered with room server.");
     strongSelf.roomId = response.roomId;

--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -184,7 +184,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
   [self registerWithRoomServerForRoomId:roomId
                       completionHandler:^(ARDRegisterResponse *response) {
     ARDAppClient *strongSelf = weakSelf;
-    if (!response) {
+    if (!response || response.result == kARDRegisterResultTypeFull) {
       NSLog(@"Failed to register with room server. Result:%d",
           (int)response.result);
       [strongSelf disconnect];

--- a/Lib/ARDAppClient.m
+++ b/Lib/ARDAppClient.m
@@ -201,7 +201,7 @@ static NSInteger kARDAppClientErrorInvalidRoom = -7;
         //Error in parsing response data
         [strongSelf disconnect];
         NSDictionary *userInfo = @{
-          NSLocalizedDescriptionKey: @"Room server network error",
+          NSLocalizedDescriptionKey: @"Room server network error"
         };
         NSError *error =
         [[NSError alloc] initWithDomain:kARDAppClientErrorDomain

--- a/Lib/ARDRegisterResponse.m
+++ b/Lib/ARDRegisterResponse.m
@@ -83,7 +83,14 @@ static NSString const *kARDRegisterWebSocketRestURLKey = @"wss_post_url";
   for (NSString *message in messages) {
     ARDSignalingMessage *signalingMessage =
         [ARDSignalingMessage messageFromJSONString:message];
-    [signalingMessages addObject:signalingMessage];
+      // Add non nil signaling message
+      if (signalingMessage) {
+          [signalingMessages addObject:signalingMessage];
+      }
+  }
+  // Error parsing signaling message JSON.
+  if ([signalingMessages count] == 0) {
+    response.result = kARDRegisterResultTypeUnknown;
   }
   response.messages = signalingMessages;
 


### PR DESCRIPTION
Error in parsing data returns nil, throwing NSInvalidArgumentException when it attempts to add a nil on the NSMutableArray, therefore causing an app crash. Added a condition to prevent crash from happening and throw an unsuccessful result instead.